### PR TITLE
🚀 Version 0.8.0 — Batch Image Extraction and Enhanced Templating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 dist/
 *.log
 main.js
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 *.log
 main.js
 .vscode/
+debug/

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ compared to traditional tools such as Tesseract.
 - Bring-your-own endpoint support for any service that follows the
   OpenAI-compatible Chat Completions API
 - Allows integration with services like:
+
   - [DeepInfra](https://deepinfra.com)
   - [Fireworks.ai](https://fireworks.ai)
   - [Together.ai](https://together.ai)
@@ -129,24 +130,44 @@ compared to traditional tools such as Tesseract.
   - Replace image embed
   - Insert at cursor
   - Create or append to another note
-- Optional header template with dynamic timestamp formatting
-- File/folder naming templates using [moment.js](https://momentjs.com/docs/#/displaying/format/)
-- Extract from embedded images or via OS-native file picker
+- Header and footer template creation with `{{placeholder}}` support
+- File/folder naming template creation with `{{placeholder}}` support
+- Extract from embedded images or via OS-native file/folder pickers
 - Built-in CORS proxy fallback for external images
 
+> [!NOTE]
+> Support for `{{placeholder}}` options is still being tested.
+> Unexpected behavior may occur.  
+> Refer to the
+> [Wiki](https://github.com/rootiest/obsidian-ai-image-ocr/wiki/Templating)
+> for available placeholders.
+> Please report any placeholder issues or suggestions on GitHub.
+
 ## Installation
+
+### Install via Obsidian Community Plugin Browser
+
+> [!NOTE]
+> This option is not yet available.
+
+1. Open Obsidian settings.
+2. Under "Community plugins", ensure "Safe mode" is disabled.
+3. Click "Browse" to open the Community Plugin Browser.
+4. Search for "AI Image OCR".
+5. Click "Install" to download the plugin.
 
 ### Install via BRAT
 
 If you have the [BRAT](https://github.com/TfTHacker/obsidian42-brat) plugin installed,
 you can install this plugin using the BRAT plugin manager:
 
-1. Click `Add beta plugin`.
-2. Enter `https://github.com/rootiest/obsidian-ai-image-ocr`
+1. Open the BRAT plugin settings.
+2. Click `Add beta plugin`.
+3. Enter `https://github.com/rootiest/obsidian-ai-image-ocr`
    in the `Repository URL` field.
-3. (Optionally) Check the `Enable after installing the plugin`
+4. (Optionally) Check the `Enable after installing the plugin`
    checkbox to enable the plugin immediately after installation.
-4. Click `Add plugin`
+5. Click `Add plugin`
 
 ### Manual Installation
 
@@ -162,33 +183,21 @@ and extract to your plugins directory.
 
 ## Configuration
 
-**These settings are required:**
-
 - Choose a model provider (`OpenAI`, `Gemini`, `Ollama`, etc.)
 - Select a model ID (e.g. `gpt-4o`, `llava:13b`, etc.)
 - If using a cloud model, enter the corresponding API key
 
-**Optional settings include:**
+Several addition optional configuration option are available with which
+you may customize the output behavior.
 
-- **Header Template**: Markdown inserted before extracted text.  
-  Can use `{{YYYY-MM-DD HH:mm:ss}}` for timestamps.
-- **Output to Another Note**: Extracted text can be routed to a new note.
-- **Folder Path**: Where to create the new note (if enabled).
-- **Filename Template**: Can include dynamic date/time formatting.
-- **Append or Overwrite**: Controls whether to reuse or recreate notes
-  with the same name.
+`{{placeholder}}` options are
+[detailed in the wiki](https://github.com/rootiest/obsidian-ai-image-ocr/wiki/Templating).
 
 ## Usage
 
-### Output Behavior
-
-- Header template (if set) will be inserted before the extracted text.
-- Output will go to a new note or current note depending on settings.
-- If extracting from an embedded image, the embed will be replaced.
-
 ### Open An Image For Extraction
 
-1. Use the command palette (`Ctrl+P`) and search for "Extract Text from Image".
+1. Use the command palette (`Ctrl+P`) and search for "Extract text from image".
 2. Select an image file.
 3. Text will be extracted and inserted per your configuration.
 
@@ -198,6 +207,13 @@ and extract to your plugins directory.
 2. Use the "Extract Text from Embedded Image" command.
 3. The nearest image above the cursor will be used as the source.
 4. The embed will be replaced by the extracted text.
+
+### Select A Folder For Extraction
+
+1. Use the command palette (`Ctrl+P`) and search for
+   "Extract text from image folder".
+2. Select a directory which contains images.
+3. Text will be extracted from each image and inserted per your configuration.
 
 ## Notes
 
@@ -230,59 +246,15 @@ and extract to your plugins directory.
 The following features are under consideration
 for future releases of the plugin:
 
-### Batch Image Processing
+### Extend Placeholder Support
 
-- **Extract from all embedded images** in a note at once.
-- **Process entire folders** of image files (e.g., screenshots, scans).
-- **Configurable output** options for batch mode:
-  - Combine all results into the active note.
-  - Create a new note for each image.
-  - Optionally include image filenames as headings or titles.
-  - Separate output configuration for single and batched extractions.
+- Add `created`/`modified` placeholders for images.
+  - Support  moment.js formatting of image placeholders.
+- Add other `{{placeholder}}` options.
 
-### Multi-image Request Batching
+### Reverse Placeholder Support
 
-When performing batched image processing:
-
-- **Send multiple images in a single API request**
-  to reduce latency and API overhead.
-- Use a defined **separator string** between images'
-  OCR results for reliable parsing into output.
-- Improve efficiency and lower cost when working with high-volume image sets.
-
-### Enhanced Output Templates
-
-Use the following dynamic properties in addition to date-time
-in output templates:
-
-- **Model and Provider names**: Use `{{model}}` or `{{provider}}`
-  in output templates.
-- **Image metadata**: Use image metadata in output templates, such as:
-  - `{{image.filename}}` for the original filename
-  - `{{image.path}}` for the full path of the image
-  - `{{image.size}}` for the image size in bytes
-  - `{{image.dimensions}}` for the image dimensions (e.g., "1920x1080")
-  - `{{image.width}}` for the image width
-  - `{{image.height}}` for the image height
-  - `{{image.created}}` for the image file creation date
-  - `{{image.modified}}` for the image file last modified date
-- **Note properties**: When outputting to a note, use:
-  - `{{note.title}}` for the note title
-  - `{{note.path}}` for the note path
-  - `{{note.created}}` for the note creation date
-  - `{{note.modified}}` for the note last modified date
-  - `{{note.frontmatter.key}}` for any frontmatter key-value pairs
-- **Other metadata**:
-  Any other relevant metadata that can be extracted from
-  the image file or note.
-
-### Other Potential Enhancements
-
-- **Custom provider name**: Allow custom naming when using custom provider.
-- **Custom model name**: Allow setting a custom name for any model used.
-- **Preview before extract**: Show a list of matched images before running OCR.
-- **Hide or obfuscate API keys**: Hide or obfuscate API keys in settings.
-- **Support for more OCR models**, including local or offline alternatives.
+- Support using a keyword to indicate where extracted text should be place in a note.
 
 > [!NOTE]
 > These goals are exploratory and may evolve based on user feedback and

--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ compared to traditional tools such as Tesseract.
 - Bring-your-own endpoint support for any service that follows the
   OpenAI-compatible Chat Completions API
 - Allows integration with services like:
-
   - [DeepInfra](https://deepinfra.com)
   - [Fireworks.ai](https://fireworks.ai)
   - [Together.ai](https://together.ai)
@@ -258,7 +257,7 @@ in output templates:
 
 - **Model and Provider names**: Use `{{model}}` or `{{provider}}`
   in output templates.
-- **Image metadata**: Use image metadate in output templates, such as:
+- **Image metadata**: Use image metadata in output templates, such as:
   - `{{image.filename}}` for the original filename
   - `{{image.path}}` for the full path of the image
   - `{{image.size}}` for the image size in bytes

--- a/main.ts
+++ b/main.ts
@@ -158,6 +158,7 @@ export default class GPTImageOCRPlugin extends Plugin {
       },
     });
 
+    // --- Batch Image Folder OCR ---
     this.addCommand({
       id: "extract-text-from-image-folder",
       name: "Extract Text from Image Folder",

--- a/main.ts
+++ b/main.ts
@@ -10,6 +10,7 @@ import {
   GPTImageOCRSettings,
   DEFAULT_SETTINGS,
   DEFAULT_PROMPT_TEXT,
+  DEFAULT_BATCH_PROMPT_TEXT,
   OCRProvider,
   PreparedImage,
 } from "./types";
@@ -328,7 +329,7 @@ For each image, wrap the response using the following format:
 
 Repeat this for each image.
 `;
-    const userPrompt = this.settings.batchCustomPrompt?.trim() || DEFAULT_PROMPT_TEXT;
+    const userPrompt = this.settings.batchCustomPrompt?.trim() || DEFAULT_BATCH_PROMPT_TEXT;
     const batchPrompt = `${userPrompt}\n${batchFormatInstruction}`;
 
     try {

--- a/main.ts
+++ b/main.ts
@@ -48,7 +48,7 @@ export default class GPTImageOCRPlugin extends Plugin {
     // --- Loaded Image OCR ---
     this.addCommand({
       id: "extract-text-from-image",
-      name: "Extract Text from Image",
+      name: "Extract text from image",
       callback: async () => {
         const file = await selectImageFile();
         if (!file) {
@@ -117,7 +117,7 @@ export default class GPTImageOCRPlugin extends Plugin {
     // --- Embedded Image OCR ---
     this.addCommand({
       id: "extract-text-from-embedded-image",
-      name: "Extract Text from Embedded Image",
+      name: "Extract text from embedded image",
       editorCallback: async (editor: Editor, ctx: MarkdownView | MarkdownFileInfo) => {
         const sel = editor.getSelection();
         const embedMatch = sel.match(/!\[\[.*?\]\]/) || sel.match(/!\[.*?\]\(.*?\)/);
@@ -223,7 +223,7 @@ export default class GPTImageOCRPlugin extends Plugin {
     // --- Batch Image Folder OCR ---
     this.addCommand({
       id: "extract-text-from-image-folder",
-      name: "Extract Text from Image Folder",
+      name: "Extract text from image folder",
       callback: () => this.extractTextFromImageFolder(),
     });
 

--- a/main.ts
+++ b/main.ts
@@ -57,7 +57,6 @@ export default class GPTImageOCRPlugin extends Plugin {
         const arrayBuffer = await file.arrayBuffer();
         const base64 = arrayBufferToBase64(arrayBuffer);
         const dims = await getImageDimensionsFromArrayBuffer(arrayBuffer);
-
         const provider = this.getProvider();
         const providerId = this.settings.provider;
         const modelId = (provider as any).model;
@@ -127,8 +126,7 @@ export default class GPTImageOCRPlugin extends Plugin {
           new Notice("No image embed found.");
           return;
         }
-        const { link, isExternal } = embed;
-
+        const { link, isExternal, embedText } = embed;
         let arrayBuffer: ArrayBuffer | null = null;
 
         if (isExternal) {
@@ -182,28 +180,28 @@ export default class GPTImageOCRPlugin extends Plugin {
             return;
           }
 
-          const embedInfo = parseEmbedInfo(sel, link);
+          const embedInfo = parseEmbedInfo(embedText, link);
           const mime = getImageMimeType(embedInfo.path);
 
-            const context = buildOCRContext({
-              providerId,
-              providerName,
-              providerType,
-              modelId,
-              modelName,
-              prompt: this.settings.customPrompt,
-              singleImage: {
-                name: embedInfo.name,
-                extension: embedInfo.extension,
-                path: embedInfo.path,
-                size: arrayBuffer?.byteLength ?? 0,
-                mime,
-                width: dims?.width,
-                height: dims?.height,
-              },
-            }) as any;
-            // Add embed info to context for downstream consumers if needed
-            context.embed = embedInfo;
+          const context = buildOCRContext({
+            providerId,
+            providerName,
+            providerType,
+            modelId,
+            modelName,
+            prompt: this.settings.customPrompt,
+            singleImage: {
+              name: embedInfo.name,
+              extension: embedInfo.extension,
+              path: embedInfo.path,
+              size: arrayBuffer?.byteLength ?? 0,
+              mime,
+              width: dims?.width,
+              height: dims?.height,
+            },
+          }) as any;
+          // Add embed info to context for downstream consumers if needed
+          context.embed = embedInfo;
           // If embed is actually selected, replace it directly
           if (embedMatch && sel === embedMatch[0]) {
             editor.replaceSelection(content);

--- a/settings-tab.ts
+++ b/settings-tab.ts
@@ -86,7 +86,7 @@ export class GPTImageOCRSettingTab extends PluginSettingTab {
     }
     if (this.plugin.settings.provider.startsWith("openai")) {
       new Setting(containerEl)
-        .setName("OpenAI API Key")
+        .setName("OpenAI API key")
         .setDesc("Your OpenAI API key")
         .addText((text) =>
           text
@@ -101,7 +101,7 @@ export class GPTImageOCRSettingTab extends PluginSettingTab {
 
     if (this.plugin.settings.provider.startsWith("gemini")) {
       new Setting(containerEl)
-        .setName("Gemini API Key")
+        .setName("Gemini API key")
         .setDesc("Your Google Gemini API key")
         .addText((text) =>
           text
@@ -207,7 +207,7 @@ export class GPTImageOCRSettingTab extends PluginSettingTab {
     if (this.plugin.settings.provider === "custom") {
 
       new Setting(containerEl)
-        .setName("Custom Provider Friendly Name")
+        .setName("Custom provider friendly name")
         .setDesc("Optional friendly name for your custom OpenAI-compatible provider.")
         .addText(text =>
           text
@@ -220,7 +220,7 @@ export class GPTImageOCRSettingTab extends PluginSettingTab {
         );
 
       new Setting(containerEl)
-        .setName("API Endpoint")
+        .setName("API endpoint")
         .setDesc("The full URL to the OpenAI-compatible /chat/completions endpoint.")
         .addText((text) =>
           text
@@ -233,7 +233,7 @@ export class GPTImageOCRSettingTab extends PluginSettingTab {
         );
 
       new Setting(containerEl)
-        .setName("Model Name")
+        .setName("Model name")
         .setDesc("Enter the model ID to use.")
         .addText((text) =>
           text
@@ -246,7 +246,7 @@ export class GPTImageOCRSettingTab extends PluginSettingTab {
         );
 
       new Setting(containerEl)
-        .setName("API Key")
+        .setName("API key")
         .setDesc("Optional. Leave empty for no key.")
         .addText((text) =>
           text
@@ -259,37 +259,57 @@ export class GPTImageOCRSettingTab extends PluginSettingTab {
         );
     }
 
-    new Setting(containerEl)
-      .setName("Custom Prompt")
-      .setDesc("Optional prompt to send to the model. Leave blank to use the default.")
-      .addTextArea((text) =>
-        text
-          .setPlaceholder("e.g., Extract any handwritten notes or text from the image.")
-          .setValue(this.plugin.settings.customPrompt)
-          .onChange(async (value) => {
-            this.plugin.settings.customPrompt = value;
-            await this.plugin.saveSettings();
-          })
-      );
+    // Add a horizontal rule to separate sections
+    containerEl.createEl("hr");
+    // Start of single image extraction settings
+    containerEl.createEl("h3", { text: "Single image extraction settings" });
 
+    // SINGLE IMAGE CUSTOM PROMPT (full-width textarea below desc)
+    const customPromptSetting = new Setting(containerEl)
+      .setName("Custom prompt")
+      .setDesc("Optional prompt to send to the model. Leave blank to use the default.");
+    const customPromptTextArea = document.createElement("textarea");
+    customPromptTextArea.placeholder = `e.g., Extract any handwritten notes or text from the image.`;
+    customPromptTextArea.value = this.plugin.settings.customPrompt;
+    customPromptTextArea.classList.add("ai-image-ocr__template-input", "ai-image-ocr__setting-input-below");
+    customPromptTextArea.rows = 2;
+    customPromptTextArea.addEventListener("change", async (e) => {
+      this.plugin.settings.customPrompt = (e.target as HTMLTextAreaElement).value;
+      await this.plugin.saveSettings();
+    });
+    customPromptSetting.infoEl.appendChild(customPromptTextArea);
+
+    // SINGLE IMAGE HEADER TEMPLATE (full-width textarea below desc)
     const headerSetting = new Setting(containerEl)
       .setName("Header template")
-      .setDesc("");
-    headerSetting.descEl.appendText("Optional markdown placed above the extracted text.");
-    headerSetting.descEl.createEl("br");
-    headerSetting.descEl.appendText("Supports {{moment.js}} formatting.");
-
-    headerSetting.addTextArea((text) => {
-      text
-        .setPlaceholder("### Extracted at {{YYYY-MM-DD HH:mm:ss}}\\n---")
-        .setValue(this.plugin.settings.headerTemplate)
-        .onChange(async (value) => {
-          this.plugin.settings.headerTemplate = value;
-          await this.plugin.saveSettings();
-        });
-      text.inputEl.classList.add("ai-image-ocr__header-textarea");
+      .setDesc("Optional markdown placed above the extracted text.\nSupports {{placeholders}}.");
+    const headerTextArea = document.createElement("textarea");
+    headerTextArea.placeholder = `### Extracted on {{YYYY-MM-DD HH:mm:ss}}
+---`;
+    headerTextArea.value = this.plugin.settings.headerTemplate;
+    headerTextArea.classList.add("ai-image-ocr__template-input", "ai-image-ocr__setting-input-below");
+    headerTextArea.rows = 3;
+    headerTextArea.addEventListener("change", async (e) => {
+      this.plugin.settings.headerTemplate = (e.target as HTMLTextAreaElement).value;
+      await this.plugin.saveSettings();
     });
+    headerSetting.infoEl.appendChild(headerTextArea);
 
+    // SINGLE IMAGE FOOTER TEMPLATE (full-width textarea below desc)
+    const footerSetting = new Setting(containerEl)
+      .setName("Footer template")
+      .setDesc("Optional markdown placed below the extracted text.\nSupports {{placeholders}}.");
+
+    const footerTextArea = document.createElement("textarea");
+    footerTextArea.placeholder = `---\n### Extracted on {{YYYY-MM-DD HH:mm:ss}}\n`;
+    footerTextArea.value = this.plugin.settings.footerTemplate;
+    footerTextArea.classList.add("ai-image-ocr__template-input", "ai-image-ocr__setting-input-below");
+    footerTextArea.rows = 3;
+    footerTextArea.addEventListener("change", async (e) => {
+      this.plugin.settings.footerTemplate = (e.target as HTMLTextAreaElement).value;
+      await this.plugin.saveSettings();
+    });
+    footerSetting.infoEl.appendChild(footerTextArea);
 
     new Setting(containerEl)
       .setName("Output to new note")
@@ -308,9 +328,9 @@ export class GPTImageOCRSettingTab extends PluginSettingTab {
       const folderSetting = new Setting(containerEl)
         .setName("Note folder path")
         .setDesc("");
-      folderSetting.descEl.appendText("Relative to vault root (e.g., 'OCR Notes')");
+      folderSetting.descEl.appendText("Relative to vault root. (e.g., 'OCR Notes')");
       folderSetting.descEl.createEl("br");
-      folderSetting.descEl.appendText("Supports {{moment.js}} formatting.");
+      folderSetting.descEl.appendText("Supports {{placeholders}}.");
       folderSetting.addText((text) =>
         text
           .setPlaceholder("OCR Notes")
@@ -323,7 +343,7 @@ export class GPTImageOCRSettingTab extends PluginSettingTab {
 
       new Setting(containerEl)
         .setName("Note name template")
-        .setDesc("Supports {{moment.js}} date formatting.")
+        .setDesc("Supports {{placeholders}}.")
         .addText((text) =>
           text
             .setPlaceholder("Extracted OCR {{YYYY-MM-DD}}")
@@ -355,12 +375,150 @@ export class GPTImageOCRSettingTab extends PluginSettingTab {
       cls: 'ai-image-ocr__tip',
     });
 
-    // Build content safely
-    descEl.createEl("strong", { text: "Tip:" });
-    descEl.appendText(" When you select the text of an image embed in the editor for extraction ");
-    descEl.createEl("code", { text: "![[image.png]]" });
-    descEl.appendText(", the extracted text will ");
-    descEl.createEl("em", { text: "replace the embed directly" });
-    descEl.appendText(" — ignoring the output-to-note and header template settings above.");
+    // Add a horizontal rule to separate sections
+    containerEl.createEl("hr");
+    // Start of batch image extraction settings
+    containerEl.createEl("h3", { text: "Batch image extraction settings" });
+
+    // BATCH CUSTOM PROMPT (full-width textarea below desc)
+    const batchCustomPromptSetting = new Setting(containerEl)
+      .setName("Custom batched images prompt")
+      .setDesc("Optional prompt to send to the model for batch extraction. Leave blank to use the default.");
+    const batchCustomPromptTextArea = document.createElement("textarea");
+    batchCustomPromptTextArea.placeholder = `e.g., Extract all visible text from each image.`;
+    batchCustomPromptTextArea.value = this.plugin.settings.batchCustomPrompt;
+    batchCustomPromptTextArea.classList.add("ai-image-ocr__template-input", "ai-image-ocr__setting-input-below");
+    batchCustomPromptTextArea.rows = 2;
+    batchCustomPromptTextArea.addEventListener("change", async (e) => {
+      this.plugin.settings.batchCustomPrompt = (e.target as HTMLTextAreaElement).value;
+      await this.plugin.saveSettings();
+    });
+    batchCustomPromptSetting.infoEl.appendChild(batchCustomPromptTextArea);
+
+    // BATCH HEADER TEMPLATE (full-width textarea below desc)
+    const batchHeaderSetting = new Setting(containerEl)
+      .setName("Batch header template")
+      .setDesc("Optional markdown placed above the extraction batch.\nSupports {{placeholders}}.");
+    const batchHeaderTextArea = document.createElement("textarea");
+    batchHeaderTextArea.placeholder = `## Extracted on {{YYYY-MM-DD HH:mm:ss}}
+---`;
+    batchHeaderTextArea.value = this.plugin.settings.batchHeaderTemplate;
+    batchHeaderTextArea.classList.add("ai-image-ocr__template-input", "ai-image-ocr__setting-input-below");
+    batchHeaderTextArea.rows = 3;
+    batchHeaderTextArea.addEventListener("change", async (e) => {
+      this.plugin.settings.batchHeaderTemplate = (e.target as HTMLTextAreaElement).value;
+      await this.plugin.saveSettings();
+    });
+    batchHeaderSetting.infoEl.appendChild(batchHeaderTextArea);
+
+    // BATCH IMAGE HEADER TEMPLATE (full-width textarea below desc)
+    const batchImageHeaderSetting = new Setting(containerEl)
+      .setName("Image header template")
+      .setDesc("Optional markdown placed above the extracted text for each image.\nSupports {{placeholders}}.");
+    const batchImageHeaderTextArea = document.createElement("textarea");
+    batchImageHeaderTextArea.placeholder = `### Extracted from {{image.name}}
+![{{image.name}}]({{image.path}})
+`;
+    batchImageHeaderTextArea.value = this.plugin.settings.batchImageHeaderTemplate;
+    batchImageHeaderTextArea.classList.add("ai-image-ocr__template-input", "ai-image-ocr__setting-input-below");
+    batchImageHeaderTextArea.rows = 3;
+    batchImageHeaderTextArea.addEventListener("change", async (e) => {
+      this.plugin.settings.batchImageHeaderTemplate = (e.target as HTMLTextAreaElement).value;
+      await this.plugin.saveSettings();
+    });
+    batchImageHeaderSetting.infoEl.appendChild(batchImageHeaderTextArea);
+
+    // BATCH IMAGE FOOTER TEMPLATE (full-width textarea below desc)
+    const batchImageFooterSetting = new Setting(containerEl)
+      .setName("Image footer template")
+      .setDesc("Optional markdown placed below the extracted text for each image.\nSupports {{placeholders}}.");
+    const batchImageFooterTextArea = document.createElement("textarea");
+    batchImageFooterTextArea.placeholder = `---
+`;
+    batchImageFooterTextArea.value = this.plugin.settings.batchImageFooterTemplate;
+    batchImageFooterTextArea.classList.add("ai-image-ocr__template-input", "ai-image-ocr__setting-input-below");
+    batchImageFooterTextArea.rows = 2;
+    batchImageFooterTextArea.addEventListener("change", async (e) => {
+      this.plugin.settings.batchImageFooterTemplate = (e.target as HTMLTextAreaElement).value;
+      await this.plugin.saveSettings();
+    });
+    batchImageFooterSetting.infoEl.appendChild(batchImageFooterTextArea);
+
+    // BATCH FOOTER TEMPLATE (full-width textarea below desc)
+    const batchFooterSetting = new Setting(containerEl)
+      .setName("Batch footer template")
+      .setDesc("Optional markdown placed below the extraction batch.\nSupports {{placeholders}}.");
+    const batchFooterTextArea = document.createElement("textarea");
+    batchFooterTextArea.placeholder = `End of Batch Extraction
+`;
+    batchFooterTextArea.value = this.plugin.settings.batchFooterTemplate;
+    batchFooterTextArea.classList.add("ai-image-ocr__template-input", "ai-image-ocr__setting-input-below");
+    batchFooterTextArea.rows = 2;
+    batchFooterTextArea.addEventListener("change", async (e) => {
+      this.plugin.settings.batchFooterTemplate = (e.target as HTMLTextAreaElement).value;
+      await this.plugin.saveSettings();
+    });
+    batchFooterSetting.infoEl.appendChild(batchFooterTextArea);
+
+    // BATCH OUTPUT TO NEW NOTE TOGGLE
+    new Setting(containerEl)
+      .setName("Output to new note")
+      .setDesc("If enabled, batch extracted text will be saved to a new note.")
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.batchOutputToNewNote)
+          .onChange(async (value) => {
+            this.plugin.settings.batchOutputToNewNote = value;
+            await this.plugin.saveSettings();
+            this.display(); // Refresh to show/hide dependent fields
+          }),
+      );
+
+    if (this.plugin.settings.batchOutputToNewNote) {
+      const batchFolderSetting = new Setting(containerEl)
+        .setName("Batch note folder path")
+        .setDesc("");
+      batchFolderSetting.descEl.appendText("Applied per image.");
+      batchFolderSetting.descEl.createEl("br");
+      batchFolderSetting.descEl.appendText("Relative to vault root. (e.g., 'OCR Notes')");
+      batchFolderSetting.descEl.createEl("br");
+      batchFolderSetting.descEl.appendText("Supports {{placeholders}}.");
+      batchFolderSetting.addText((text) =>
+        text
+          .setPlaceholder("OCR Notes")
+          .setValue(this.plugin.settings.batchNoteFolderPath)
+          .onChange(async (value) => {
+            this.plugin.settings.batchNoteFolderPath = value.trim();
+            await this.plugin.saveSettings();
+          })
+      );
+
+      new Setting(containerEl)
+        .setName("Batch note name template")
+        .setDesc("Applied per image. Supports {{placeholders}}.")
+        .addText((text) =>
+          text
+            .setPlaceholder("Batch OCR {{YYYY-MM-DD}}")
+            .setValue(this.plugin.settings.batchNoteNameTemplate)
+            .onChange(async (value) => {
+              this.plugin.settings.batchNoteNameTemplate = value;
+              await this.plugin.saveSettings();
+            }),
+        );
+
+      new Setting(containerEl)
+        .setName("Batch append if file exists")
+        .setDesc(
+          "If enabled, appends to an existing note instead of creating a new one for batch output.",
+        )
+        .addToggle((toggle) =>
+          toggle
+            .setValue(this.plugin.settings.batchAppendIfExists)
+            .onChange(async (value) => {
+              this.plugin.settings.batchAppendIfExists = value;
+              await this.plugin.saveSettings();
+            }),
+        );
+    }
   }
 }

--- a/settings-tab.ts
+++ b/settings-tab.ts
@@ -157,6 +157,19 @@ export class GPTImageOCRSettingTab extends PluginSettingTab {
           cls: "setting-item-warning"
         });
       }
+
+      new Setting(containerEl)
+        .setName("Model friendly name")
+        .setDesc("Optional. Friendly display name for this model (e.g. 'Llama 3.2 Vision').")
+        .addText(text =>
+          text
+            .setPlaceholder("Llama 3.2 Vision")
+            .setValue(this.plugin.settings.ollamaModelFriendlyName || "")
+            .onChange(async (value) => {
+              this.plugin.settings.ollamaModelFriendlyName = value.trim();
+              await this.plugin.saveSettings();
+            })
+        );
     }
 
     if (this.plugin.settings.provider === "lmstudio") {
@@ -202,6 +215,19 @@ export class GPTImageOCRSettingTab extends PluginSettingTab {
           cls: "setting-item-warning"
         });
       }
+
+      new Setting(containerEl)
+        .setName("Model friendly name")
+        .setDesc("Optional. Friendly display name for this model (e.g. 'Gemma 3').")
+        .addText(text =>
+          text
+            .setPlaceholder("Gemma 3")
+            .setValue(this.plugin.settings.lmstudioModelFriendlyName || "")
+            .onChange(async (value) => {
+              this.plugin.settings.lmstudioModelFriendlyName = value.trim();
+              await this.plugin.saveSettings();
+            })
+        );
     }
 
     if (this.plugin.settings.provider === "custom") {
@@ -256,6 +282,19 @@ export class GPTImageOCRSettingTab extends PluginSettingTab {
               this.plugin.settings.customApiKey = value.trim();
               await this.plugin.saveSettings();
             }),
+        );
+
+      new Setting(containerEl)
+        .setName("Model friendly name")
+        .setDesc("Optional. Friendly display name for this model (e.g. 'My Custom Model').")
+        .addText(text =>
+          text
+            .setPlaceholder("My Custom Model")
+            .setValue(this.plugin.settings.customModelFriendlyName || "")
+            .onChange(async (value) => {
+              this.plugin.settings.customModelFriendlyName = value.trim();
+              await this.plugin.saveSettings();
+            })
         );
     }
 

--- a/settings-tab.ts
+++ b/settings-tab.ts
@@ -187,7 +187,7 @@ export class GPTImageOCRSettingTab extends PluginSettingTab {
         );
       const customUrlDesc = containerEl.createEl("div", { cls: "ai-image-ocr__setting-desc" });
       customUrlDesc.appendText("e.g. ");
-      customUrlDesc.createEl("code", { text: "http://localhost:11434" });
+      customUrlDesc.createEl("code", { text: "http://localhost:1234" });
 
       // LMStudio Model Name
       new Setting(containerEl)

--- a/styles.css
+++ b/styles.css
@@ -45,3 +45,13 @@
   font-weight: 600;
 }
 
+.ai-image-ocr__template-input {
+  width: 100%;
+  min-height: 6em;
+  font-family: var(--font-text);
+  box-sizing: border-box;
+}
+
+.ai-image-ocr__setting-input-below {
+  margin-top: 0.5em;
+}

--- a/types.ts
+++ b/types.ts
@@ -19,6 +19,7 @@ export interface GPTImageOCRSettings {
   | "ollama"
   | "lmstudio"
   | "custom";
+
   openaiApiKey: string;
   geminiApiKey: string;
   ollamaUrl: string;
@@ -29,12 +30,26 @@ export interface GPTImageOCRSettings {
   customApiUrl: string;
   customApiModel: string;
   customApiKey: string;
+
+  // Single image settings
   customPrompt: string;
   outputToNewNote: boolean;
   noteFolderPath: string;
   noteNameTemplate: string;
   appendIfExists: boolean;
   headerTemplate: string;
+  footerTemplate: string;
+
+  // Batch image settings (add these)
+  batchCustomPrompt: string;
+  batchOutputToNewNote: boolean;
+  batchNoteFolderPath: string;
+  batchNoteNameTemplate: string;
+  batchAppendIfExists: boolean;
+  batchHeaderTemplate: string;
+  batchImageHeaderTemplate: string; // Optional header for each image in batch
+  batchImageFooterTemplate: string; // Optional footer for each image in batch
+  batchFooterTemplate: string;
 }
 
 export const DEFAULT_PROMPT_TEXT =
@@ -69,10 +84,22 @@ export const DEFAULT_SETTINGS: GPTImageOCRSettings = {
   customApiKey: "",
   customPrompt: "",
   outputToNewNote: false,
-  noteFolderPath: "",
+  noteFolderPath: "OCR Notes",
   noteNameTemplate: "Extracted OCR {{YYYY-MM-DD HH-mm-ss}}",
   appendIfExists: false,
   headerTemplate: "",
+  footerTemplate: "",
+
+  // Batch image settings
+  batchCustomPrompt: "",
+  batchOutputToNewNote: false,
+  batchNoteFolderPath: "OCR Notes",
+  batchNoteNameTemplate: "Batch OCR {{YYYY-MM-DD HH-mm-ss}}",
+  batchAppendIfExists: false,
+  batchHeaderTemplate: "",
+  batchImageHeaderTemplate: "",
+  batchImageFooterTemplate: "",
+  batchFooterTemplate: "",
 };
 
 
@@ -84,7 +111,6 @@ export interface OCRProvider {
   // Multi-image + prompt handler (used by batch and prompt-aware workflows)
   process?(images: PreparedImage[], prompt: string): Promise<string>;
 }
-
 
 export type GeminiPayload = {
   contents: Array<{
@@ -150,5 +176,26 @@ export interface PreparedImage {
   mime: string;
   size: number;
   source: string; // original source path or URL
+}
+
+export interface OCRFormatContext {
+  provider?: string;
+  providerName?: string;
+  model?: string;
+  prompt?: string;
+  image?: {
+    name?: string;
+    path?: string;
+    size?: number;
+    mime?: string;
+    [key: string]: any;
+  };
+  note?: {
+    name?: string;
+    path?: string;
+    folder?: string;
+    [key: string]: any;
+  };
+  [key: string]: any; // for extensibility
 }
 

--- a/types.ts
+++ b/types.ts
@@ -55,6 +55,9 @@ export interface GPTImageOCRSettings {
 export const DEFAULT_PROMPT_TEXT =
   "Extract only the raw text from this image. Do not add commentary or explanations. Do not prepend anything. Return only the transcribed text in markdown format. Do not put a markdown codeblock around the returned text.";
 
+export const DEFAULT_BATCH_PROMPT_TEXT =
+  "Extract only the raw text from each image. Do not add commentary or explanations. Do not prepend anything. Return only the transcribed text in markdown format for each image. Do not put a markdown codeblock around the returned text.";
+
 export const FRIENDLY_PROVIDER_NAMES: Record<GPTImageOCRSettings["provider"], string> = {
   "openai": "OpenAI GPT-4o",
   "openai-mini": "OpenAI GPT-4o Mini",

--- a/types.ts
+++ b/types.ts
@@ -50,6 +50,10 @@ export interface GPTImageOCRSettings {
   batchImageHeaderTemplate: string; // Optional header for each image in batch
   batchImageFooterTemplate: string; // Optional footer for each image in batch
   batchFooterTemplate: string;
+
+  ollamaModelFriendlyName?: string;
+  lmstudioModelFriendlyName?: string;
+  customModelFriendlyName?: string;
 }
 
 export const DEFAULT_PROMPT_TEXT =
@@ -59,17 +63,32 @@ export const DEFAULT_BATCH_PROMPT_TEXT =
   "Extract only the raw text from each image. Do not add commentary or explanations. Do not prepend anything. Return only the transcribed text in markdown format for each image. Do not put a markdown codeblock around the returned text.";
 
 export const FRIENDLY_PROVIDER_NAMES: Record<GPTImageOCRSettings["provider"], string> = {
-  "openai": "OpenAI GPT-4o",
-  "openai-mini": "OpenAI GPT-4o Mini",
-  "openai-4.1": "OpenAI GPT-4.1",
-  "openai-4.1-mini": "OpenAI GPT-4.1 Mini",
-  "openai-4.1-nano": "OpenAI GPT-4.1 Nano",
-  "gemini": "Google Gemini 2.5 Flash",
-  "gemini-lite": "Google Gemini 2.5 Flash-Lite Preview 06-17",
-  "gemini-pro": "Google Gemini 2.5 Pro",
+  "openai": "OpenAI",
+  "openai-mini": "OpenAI",
+  "openai-4.1": "OpenAI",
+  "openai-4.1-mini": "OpenAI",
+  "openai-4.1-nano": "OpenAI",
+  "gemini": "Google",
+  "gemini-lite": "Google",
+  "gemini-pro": "Google",
   "ollama": "Ollama",
   "lmstudio": "LMStudio",
   "custom": "Custom Provider"
+};
+
+export const FRIENDLY_MODEL_NAMES: Record<string, string> = {
+  "gpt-4o": "GPT-4o",
+  "gpt-4o-mini": "GPT-4o Mini",
+  "gpt-4.1": "GPT-4.1",
+  "gpt-4.1-mini": "GPT-4.1 Mini",
+  "gpt-4.1-nano": "GPT-4.1 Nano",
+  "llama3.2-vision": "Llama 3.2 Vision",
+  "gemma3": "Gemma 3",
+  "gemini-2.5-flash": "Gemini Flash 2.5",
+  "models/gemini-2.5-flash": "Gemini Flash 2.5",
+  "models/gemini-2.5-flash-lite-preview-06-17": "Gemini Flash-Lite Preview 06-17",
+  "models/gemini-2.5-pro": "Gemini Pro 2.5",
+  // Add more as needed
 };
 
 export const DEFAULT_SETTINGS: GPTImageOCRSettings = {
@@ -103,6 +122,10 @@ export const DEFAULT_SETTINGS: GPTImageOCRSettings = {
   batchImageHeaderTemplate: "",
   batchImageFooterTemplate: "",
   batchFooterTemplate: "",
+
+  ollamaModelFriendlyName: "",
+  lmstudioModelFriendlyName: "",
+  customModelFriendlyName: "",
 };
 
 

--- a/types.ts
+++ b/types.ts
@@ -3,9 +3,10 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-import { RequestUrlResponse } from "obsidian";
+import { TFile } from "obsidian";
 
 export interface GPTImageOCRSettings {
+  providerType: "openai" | "gemini";
   provider:
   | "openai"
   | "openai-mini"
@@ -54,6 +55,7 @@ export const FRIENDLY_PROVIDER_NAMES: Record<GPTImageOCRSettings["provider"], st
 };
 
 export const DEFAULT_SETTINGS: GPTImageOCRSettings = {
+  providerType: "openai",
   provider: "openai",
   openaiApiKey: "",
   geminiApiKey: "",
@@ -73,11 +75,16 @@ export const DEFAULT_SETTINGS: GPTImageOCRSettings = {
   headerTemplate: "",
 };
 
+
 export interface OCRProvider {
   id: string;
   name: string;
+  // Legacy single-image handler (still used by some commands)
   extractTextFromBase64(image: string): Promise<string | null>;
+  // Multi-image + prompt handler (used by batch and prompt-aware workflows)
+  process?(images: PreparedImage[], prompt: string): Promise<string>;
 }
+
 
 export type GeminiPayload = {
   contents: Array<{
@@ -130,3 +137,18 @@ export type LmstudioPayload = {
   }>;
   max_tokens: number;
 };
+
+export interface CollectedImage {
+  source: string; // The original markdown/image link
+  file?: TFile;   // If it's a local vault file
+  isExternal: boolean;
+}
+
+export interface PreparedImage {
+  name: string;
+  base64: string;
+  mime: string;
+  size: number;
+  source: string; // original source path or URL
+}
+

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -242,16 +242,16 @@ export function applyFormatting(
       };
       const imgHeader = formatTemplate(plugin.settings.batchImageHeaderTemplate || "", imgContext);
       const imgFooter = formatTemplate(plugin.settings.batchImageFooterTemplate || "", imgContext);
-      return [imgHeader, imgText, imgFooter].filter(Boolean).join("\n\n");
+      return [imgHeader, imgText, imgFooter].filter(Boolean).join("");
     });
 
-    return [batchHeader, ...formattedImages, batchFooter].filter(Boolean).join("\n\n");
+    return [batchHeader, ...formattedImages, batchFooter].filter(Boolean).join("");
   }
 
   // Single image mode
   const header = formatTemplate(plugin.settings.headerTemplate || "", context);
   const footer = formatTemplate(plugin.settings.footerTemplate || "", context);
-  return [header, content as string, footer].filter(Boolean).join("\n\n");
+  return [header, content as string, footer].filter(Boolean).join("");
 }
 
 /**

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -273,6 +273,10 @@ export function formatTemplate(template: string, context: Record<string, any> = 
         return context.image?.gps?.longitude ?? "";
       case "image.gps.altitude":
         return context.image?.gps?.altitude ?? "";
+      case "embed.altText":
+        return context.embed?.altText ?? "";
+      case "embed.url":
+        return context.embed?.path ?? context.embed?.url ?? "";
       default:
         return "";
     }
@@ -464,13 +468,14 @@ export function findRelevantImageEmbed(editor: Editor): {
   link: string;
   isExternal: boolean;
   embedType: "internal" | "external";
+  embedText: string;
 } | null {
   // 1. Check selection
   const sel = editor.getSelection();
   let match = sel.match(/!\[\[(.+?)\]\]/);
   if (match) {
     const link = match[1].split("|")[0].trim();
-    return { link, isExternal: false, embedType: "internal" };
+    return { link, isExternal: false, embedType: "internal", embedText: match[0] };
   }
   match = sel.match(/!\[.*?\]\((.+?)\)/);
   if (match) {
@@ -479,6 +484,7 @@ export function findRelevantImageEmbed(editor: Editor): {
       link,
       isExternal: /^https?:\/\//i.test(link),
       embedType: "external",
+      embedText: match[0],
     };
   }
 
@@ -488,7 +494,7 @@ export function findRelevantImageEmbed(editor: Editor): {
     let embedMatch = line.match(/!\[\[(.+?)\]\]/);
     if (embedMatch) {
       const link = embedMatch[1].split("|")[0].trim();
-      return { link, isExternal: false, embedType: "internal" };
+      return { link, isExternal: false, embedType: "internal", embedText: embedMatch[0] };
     }
     embedMatch = line.match(/!\[.*?\]\((.+?)\)/);
     if (embedMatch) {
@@ -497,6 +503,7 @@ export function findRelevantImageEmbed(editor: Editor): {
         link,
         isExternal: /^https?:\/\//i.test(link),
         embedType: "external",
+        embedText: embedMatch[0],
       };
     }
   }
@@ -651,8 +658,8 @@ export function buildOCRContext({
   modelId: string;
   modelName: string;
   prompt: string;
-  images?: Array<{ name: string; path: string; size: number; mime: string; extension: string; width?: number; height?: number }>;
-  singleImage?: { name: string; path: string; size: number; mime: string; extension: string; width?: number; height?: number };
+  images?: Array<{ name: string; path: string; size: number; mime: string; extension: string; width?: number; height?: number, created?: string; modified?: string; altText?: string; gps?: { latitude?: number; longitude?: number; altitude?: number } }>;
+  singleImage?: { name: string; path: string; size: number; mime: string; extension: string; width?: number; height?: number, created?: string; modified?: string;  altText?: string;  gps?: { latitude?: number; longitude?: number; altitude?: number } };
 }) {
   const base = {
     provider: {

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -751,3 +751,7 @@ export function parseEmbedInfo(embedMarkdown: string, link: string) {
     altText,
   };
 }
+
+export function templateHasImagePlaceholder(template: string): boolean {
+  return /\{\{\s*image\.[^}]+\s*\}\}/.test(template);
+}

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -319,7 +319,8 @@ export function applyFormatting(
       };
       const imgHeader = formatTemplate(plugin.settings.batchImageHeaderTemplate || "", imgContext);
       const imgFooter = formatTemplate(plugin.settings.batchImageFooterTemplate || "", imgContext);
-      return [imgHeader, imgText, imgFooter].filter(Boolean).join("");
+      // Add a newline before imgFooter if imgFooter is not empty
+      return [imgHeader, imgText, imgFooter ? "\n" + imgFooter : ""].filter(Boolean).join("");
     });
 
     return [batchHeader, ...formattedImages, batchFooter].filter(Boolean).join("");
@@ -328,7 +329,7 @@ export function applyFormatting(
   // Single image mode
   const header = formatTemplate(plugin.settings.headerTemplate || "", context);
   const footer = formatTemplate(plugin.settings.footerTemplate || "", context);
-  return [header, content as string, footer].filter(Boolean).join("");
+  return [header, content as string, footer ? "\n" + footer : ""].filter(Boolean).join("");
 }
 
 /**
@@ -340,6 +341,11 @@ export async function handleExtractedContent(
   editor: Editor | null,
   context: Record<string, any> = {}
 ) {
+  // Fallback to active editor if not provided
+  if (!editor) {
+    editor = plugin.app.workspace.activeEditor?.editor ?? null;
+  }
+
   // Use the new formatting function
   const finalContent = applyFormatting(plugin, content, context);
 

--- a/utils/ocr-utils.ts
+++ b/utils/ocr-utils.ts
@@ -1,0 +1,24 @@
+import type { OCRProvider, PreparedImage } from "../types";
+
+export async function processSingleImage(
+  provider: OCRProvider,
+  base64: string,
+  mime: string = "image/jpeg",
+  prompt: string = "What does this say?"
+): Promise<string> {
+  const image: PreparedImage = {
+    name: "image.jpg",
+    base64,
+    mime,
+    size: base64.length * 0.75,
+    source: "inline",
+  };
+
+  if (provider.process) {
+    return await provider.process([image], prompt);
+  } else {
+    const result = await provider.extractTextFromBase64(base64);
+    return result ?? "";
+  }
+}
+


### PR DESCRIPTION
## 🚀 Version 0.8.0 — Batch Image Extraction and Enhanced Templating

This PR introduces the first working implementation of **batch image extraction** for the AI Image OCR plugin.

---

### ✅ Completed Features

- [x] Folder-based image selection
- [x] Processes all valid images in a folder and sends them as a **single API request**
- [x] Basic output directly to the current note
- [x] Output behavior options:
  - One note per image
  - One combined note with **custom separator text**
  - Output inline in current note with **custom separator text**
- [x] Improved file filtering (skips non-images, corrupt files, etc.)
- [x] Separate templating options for **batched** and **single** image outputs:
  - Customizable header/footer for the entire batch output
  - Customizable header/footer for each image within a batch
  - Distinct file naming and path rules for batched vs. single-image output
- [x] Enhanced output templating with dynamic placeholders:
  - General: `{{model}}`, `{{provider}}`
  - Image metadata: `{{image.name}}`, `{{image.dimensions}}`, etc.
  - Note metadata: `{{note.title}}`, `{{note.frontmatter.tags}}`, etc.

> [!TIP]  
> Refer to the [Templating Guide](https://github.com/rootiest/obsidian-ai-image-ocr/wiki/Templating#-template-placeholder-reference) in the Wiki for a full list of supported placeholders.

---

### ⚠️ Known Limitations

- Token limits are not currently checked — large batches **may cause errors** or fail silently.

---

### 🔜 Planned for Future Releases

- [ ] Support extracting from **all image embeds** in the current note  
- [ ] Intelligent batching with **automatic splitting** based on token limits  
- [ ] Add “Process images individually” setting to bypass batch API calls
- [ ] Additional template placeholders:
  - `{{note}}` object for accessing frontmatter and note metadata
  - `{{image.created}}`, `{{image.modified}}` with Moment.js formatting
  - Image **EXIF metadata** (where available)

> [!NOTE]  
> The inclusion of proposed placeholders is not guaranteed.  
> Their availability will depend on feasibility and technical constraints.
