### PR TITLE
Add image dimension placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,8 @@ in output templates:
   - `{{image.path}}` for the full path of the image
   - `{{image.size}}` for the image size in bytes
   - `{{image.dimensions}}` for the image dimensions (e.g., "1920x1080")
+  - `{{image.width}}` for the image width
+  - `{{image.height}}` for the image height
   - `{{image.created}}` for the image file creation date
   - `{{image.modified}}` for the image file last modified date
 - **Note properties**: When outputting to a note, use:

--- a/main.ts
+++ b/main.ts
@@ -24,6 +24,7 @@ import {
   resolveInternalImagePath,
   fetchExternalImageAsArrayBuffer,
   arrayBufferToBase64,
+  getImageDimensionsFromArrayBuffer,
   selectImageFile,
   selectFolder,
   getProviderType,
@@ -55,6 +56,7 @@ export default class GPTImageOCRPlugin extends Plugin {
         }
         const arrayBuffer = await file.arrayBuffer();
         const base64 = arrayBufferToBase64(arrayBuffer);
+        const dims = await getImageDimensionsFromArrayBuffer(arrayBuffer);
 
         const provider = this.getProvider();
         const providerId = this.settings.provider;
@@ -95,6 +97,8 @@ export default class GPTImageOCRPlugin extends Plugin {
                 path: file.name,
                 size: file.size,
                 mime,
+                width: dims?.width,
+                height: dims?.height,
               },
             });
 
@@ -149,6 +153,7 @@ export default class GPTImageOCRPlugin extends Plugin {
           return;
         }
         const base64 = arrayBufferToBase64(arrayBuffer);
+        const dims = await getImageDimensionsFromArrayBuffer(arrayBuffer);
 
         const provider = this.getProvider();
         const providerId = this.settings.provider;
@@ -193,6 +198,8 @@ export default class GPTImageOCRPlugin extends Plugin {
                 path: embedInfo.path,
                 size: arrayBuffer?.byteLength ?? 0,
                 mime,
+                width: dims?.width,
+                height: dims?.height,
               },
             }) as any;
             // Add embed info to context for downstream consumers if needed
@@ -358,11 +365,14 @@ export default class GPTImageOCRPlugin extends Plugin {
     const prepared = await Promise.all(
       imageFiles.map(async (file): Promise<PreparedImage> => {
         const arrayBuffer = await file.arrayBuffer();
+        const dims = await getImageDimensionsFromArrayBuffer(arrayBuffer);
         return {
           name: file.name,
           base64: arrayBufferToBase64(arrayBuffer),
           mime: file.type,
           size: file.size,
+          width: dims?.width,
+          height: dims?.height,
           source: file.name,
         };
       })
@@ -438,6 +448,8 @@ Repeat this for each image.
             path: img.source,
             size: img.size,
             mime: img.mime || getImageMimeType(img.name),
+            width: img.width,
+            height: img.height,
           })),
         });
       } else {
@@ -455,6 +467,8 @@ Repeat this for each image.
             path: prepared[0]?.source,
             size: prepared[0]?.size,
             mime: prepared[0]?.mime || getImageMimeType(prepared[0]?.name ?? ""),
+            width: prepared[0]?.width,
+            height: prepared[0]?.height,
           },
         });
       }

--- a/types.ts
+++ b/types.ts
@@ -201,6 +201,8 @@ export interface PreparedImage {
   base64: string;
   mime: string;
   size: number;
+  width?: number;
+  height?: number;
   source: string; // original source path or URL
 }
 


### PR DESCRIPTION
## Summary
- compute image width and height when preparing context
- expose `getImageDimensionsFromArrayBuffer` helper
- include width and height in `PreparedImage` and OCR context
- document new template placeholders for width and height

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6869374cc9b0832c91db6627eaadf0c7