### PR TITLE
Add optional debug logging

### DIFF
--- a/utils/editor.ts
+++ b/utils/editor.ts
@@ -4,12 +4,13 @@
 // https://opensource.org/licenses/MIT
 
 import { Editor, EditorPosition } from "obsidian";
-import { pluginLog } from "./log";
+import { pluginLog, pluginLogger } from "./log";
 
 /**
  * Moves the editor cursor to the end of the document and scrolls into view.
  */
 export function moveCursorToEnd(editor: Editor) {
+  pluginLogger("Moving cursor to end");
   requestAnimationFrame(() => {
     const lastLine = editor.lastLine();
     const lastCh = editor.getLine(lastLine)?.length || 0;
@@ -22,6 +23,7 @@ export function moveCursorToEnd(editor: Editor) {
  * Scrolls the editor view to the current cursor position.
  */
 export function scrollEditorToCursor(editor: Editor) {
+  pluginLogger("Scrolling editor to cursor");
   try {
     const maybeCM = (editor as Editor & { cm?: unknown }).cm;
     if (

--- a/utils/log.ts
+++ b/utils/log.ts
@@ -59,3 +59,14 @@ export function pluginLog(
     }
   }
 }
+
+/**
+ * Alias for pluginLog used for debug output.
+ */
+export function pluginLogger(
+  message: string | Error,
+  type: "log" | "warn" | "error" | "notice" | "permanent" = "log",
+  always: boolean = false
+) {
+  pluginLog(message, type, always);
+}


### PR DESCRIPTION
## Summary
- add `pluginLogger` helper
- sprinkle `pluginLogger` calls for optional debug logging
- provide debug statements in main plugin and utility modules

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687034eecd4c832c97aade158ee1c79a